### PR TITLE
Avoid fatal cmake error when CGAL is missing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # use glob syntax.
 syntax: glob
 scripts/change_name.sh
+build
 *.so
 *.so.[0123456789]
 *.so.[0123456789].[0123456789]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ find_package(EIGEN REQUIRED)
 include_directories( ${EIGEN_INCLUDE_DIR})
 
 find_package(CORK QUIET)
-find_package(CGAL REQUIRED)
+find_package(CGAL QUIET)
 find_package(EMBREE QUIET)
 find_package(LIBCOMISO QUIET)
 find_package(MATLAB QUIET)


### PR DESCRIPTION
Very small change to cmake file.
