### PR TITLE
test for edge_lengths cotmatrix 

### DIFF
--- a/include/igl/cotmatrix.cpp
+++ b/include/igl/cotmatrix.cpp
@@ -28,3 +28,140 @@ INSTANTIATE_TEST_CASE_P
  ::testing::ValuesIn(test_common::all_meshes()),
  test_common::string_test_name
 );
+
+TEST(cotmatrix, cube)
+{
+  //The allowed error for this test
+  const double epsilon = 1e-15;
+
+  Eigen::MatrixXd V;
+  Eigen::MatrixXi F;
+  //This is a cube of dimensions 1.0x1.0x1.0
+  test_common::load_mesh("cube.obj", V, F);
+
+  //Scale the cube to have huge sides
+  Eigen::MatrixXd V_huge = V * 1.0e8;
+
+  //Scale the cube to have tiny sides
+  Eigen::MatrixXd V_tiny = V * 1.0e-8;
+
+  //Check cotmatrix (Laplacian)
+  //The laplacian for the cube is quite singular.
+  //Each edge in a diagonal has two opposite angles of 90, with cotangent 0.0 each
+  //Each edge in a side has two opposite angle of 45, with (half)cotangen 0.5 each
+  //So the cotangent matrix always are (0+0) or (0.5+0.5)
+  Eigen::SparseMatrix<double> L1;
+  igl::cotmatrix(V,F,L1);
+  ASSERT_EQ(V.rows(), L1.rows());
+  ASSERT_EQ(V.rows(), L1.cols());
+  for(int f = 0;f<L1.rows();f++)
+  {
+    ASSERT_EQ(-3.0, L1.coeff(f,f));
+    ASSERT_EQ(0.0, L1.row(f).sum());
+    ASSERT_EQ(0.0, L1.col(f).sum());
+  }
+
+  //Same for huge cube.
+  igl::cotmatrix(V_huge,F,L1);
+  ASSERT_EQ(V.rows(), L1.rows());
+  ASSERT_EQ(V.rows(), L1.cols());
+  for(int f = 0;f<L1.rows();f++)
+  {
+    ASSERT_NEAR(-3.0, L1.coeff(f,f), epsilon);
+    ASSERT_NEAR(0.0, L1.row(f).sum(), epsilon);
+    ASSERT_NEAR(0.0, L1.col(f).sum(), epsilon);
+  }
+
+  //Same for tiny cube. we need to use a tolerance this time...
+  igl::cotmatrix(V_tiny,F,L1);
+  ASSERT_EQ(V.rows(), L1.rows());
+  ASSERT_EQ(V.rows(), L1.cols());
+  for(int f = 0;f<L1.rows();f++)
+  {
+    ASSERT_NEAR(-3.0, L1.coeff(f,f), epsilon);
+    ASSERT_NEAR(0.0, L1.row(f).sum(), epsilon);
+    ASSERT_NEAR(0.0, L1.col(f).sum(), epsilon);
+  }
+
+}//TEST(cotmatrix, cube)
+
+TEST(cotmatrix, tetrahedron)
+{
+  //The allowed error for this test
+  const double epsilon = 1e-15;
+
+  Eigen::MatrixXd V;
+  Eigen::MatrixXi F;
+  //This is a cube of dimensions 1.0x1.0x1.0
+  test_common::load_mesh("cube.obj", V, F);
+
+  //Prepare another mesh with triangles along side diagonals of the cube
+  //These triangles are form a regular tetrahedron of side sqrt(2)
+  Eigen::MatrixXi F_equi(4,3);
+  F_equi << 4,6,1,
+            6,4,3,
+            4,1,3,
+            1,6,3;
+
+  //Scale the cube to have huge sides
+  Eigen::MatrixXd V_huge = V * 1.0e8;
+
+  //Scale the cube to have tiny sides
+  Eigen::MatrixXd V_tiny = V * 1.0e-8;
+
+  //Check cotmatrix (Laplacian)
+  //The laplacian for the cube is quite singular.
+  //Each edge in a diagonal has two opposite angles of 90, with cotangent 0.0 each
+  //Each edge in a side has two opposite angle of 45, with (half)cotangen 0.5 each
+  //So the cotangent matrix always are (0+0) or (0.5+0.5)
+  Eigen::SparseMatrix<double> L1;
+
+  //Check the regular tetrahedron of side sqrt(2)
+  igl::cotmatrix(V,F_equi,L1);
+
+  ASSERT_EQ(V.rows(), L1.rows());
+  ASSERT_EQ(V.rows(), L1.cols());
+  for(int f = 0;f<L1.rows();f++)
+  {
+    //Check the diagonal. Only can value 0.0 for unused vertex or -3 / tan(60)
+    if (L1.coeff(f,f) < -0.1)
+        ASSERT_NEAR(-3 / tan(M_PI / 3.0), L1.coeff(f,f), epsilon);
+    else
+        ASSERT_NEAR(0.0, L1.coeff(f,f), epsilon);
+    ASSERT_EQ(0.0, L1.row(f).sum());
+    ASSERT_EQ(0.0, L1.col(f).sum());
+  }
+
+  //Check the huge regular tetrahedron
+  igl::cotmatrix(V_huge,F_equi,L1);
+
+  ASSERT_EQ(V.rows(), L1.rows());
+  ASSERT_EQ(V.rows(), L1.cols());
+  for(int f = 0;f<L1.rows();f++)
+  {
+    //Check the diagonal. Only can value 0.0 for unused vertex or -3 / tan(60)
+    if (L1.coeff(f,f) < -0.1)
+        ASSERT_NEAR(-3 / tan(M_PI / 3.0), L1.coeff(f,f), epsilon);
+    else
+        ASSERT_NEAR(0.0, L1.coeff(f,f), epsilon);
+    ASSERT_NEAR(0.0, L1.row(f).sum(), epsilon);
+    ASSERT_NEAR(0.0, L1.col(f).sum(), epsilon);
+  }
+
+  //Check the tiny regular tetrahedron
+  igl::cotmatrix(V_tiny,F_equi,L1);
+
+  ASSERT_EQ(V.rows(), L1.rows());
+  ASSERT_EQ(V.rows(), L1.cols());
+  for(int f = 0;f<L1.rows();f++)
+  {
+    //Check the diagonal. Only can value 0.0 for unused vertex or -3 / tan(60)
+    if (L1.coeff(f,f) < -0.1)
+        ASSERT_NEAR(-3 / tan(M_PI / 3.0), L1.coeff(f,f), epsilon);
+    else
+        ASSERT_NEAR(0.0, L1.coeff(f,f), epsilon);
+    ASSERT_NEAR(0.0, L1.row(f).sum(), epsilon);
+    ASSERT_NEAR(0.0, L1.col(f).sum(), epsilon);
+  }
+
+}//TEST(cotmatrix, tetrahedron)

--- a/include/igl/cotmatrix.cpp
+++ b/include/igl/cotmatrix.cpp
@@ -56,9 +56,18 @@ TEST(cotmatrix, cube)
   ASSERT_EQ(V.rows(), L1.cols());
   for(int f = 0;f<L1.rows();f++)
   {
+#ifdef IGL_EDGE_LENGTHS_SQUARED_H
+    //Hard assert if we have edge_lenght_squared
     ASSERT_EQ(-3.0, L1.coeff(f,f));
     ASSERT_EQ(0.0, L1.row(f).sum());
     ASSERT_EQ(0.0, L1.col(f).sum());
+#else
+    //Soft assert if we have not edge_lenght_squared
+    ASSERT_NEAR(-3.0, L1.coeff(f,f), epsilon);
+    ASSERT_NEAR(0.0, L1.row(f).sum(), epsilon);
+    ASSERT_NEAR(0.0, L1.col(f).sum(), epsilon);
+#endif
+
   }
 
   //Same for huge cube.
@@ -128,8 +137,15 @@ TEST(cotmatrix, tetrahedron)
         ASSERT_NEAR(-3 / tan(M_PI / 3.0), L1.coeff(f,f), epsilon);
     else
         ASSERT_NEAR(0.0, L1.coeff(f,f), epsilon);
+#ifdef IGL_EDGE_LENGTHS_SQUARED_H
+    //Hard assert if we have edge_lenght_squared
     ASSERT_EQ(0.0, L1.row(f).sum());
     ASSERT_EQ(0.0, L1.col(f).sum());
+#else
+    //Soft assert if we have not edge_lenght_squared
+    ASSERT_NEAR(0.0, L1.row(f).sum(), epsilon);
+    ASSERT_NEAR(0.0, L1.col(f).sum(), epsilon);
+#endif
   }
 
   //Check the huge regular tetrahedron

--- a/include/igl/cotmatrix_entries.cpp
+++ b/include/igl/cotmatrix_entries.cpp
@@ -29,13 +29,25 @@ TEST(cotmatrix_entries, simple)
   //Their (half)cotangent must value 0.5 or 0.0
   for(int f = 0;f<C1.rows();f++)
   {
-    for(int v = 0;v<3;v++)
+#ifdef IGL_EDGE_LENGTHS_SQUARED_H
+      //Hard assert if we have edge_lenght_squared
+      for(int v = 0;v<3;v++)
         if (C1(f,v) > 0.1)
-           ASSERT_EQ(0.5, C1(f,v));
+            ASSERT_EQ(0.5, C1(f,v));
         else
            ASSERT_EQ(0.0, C1(f,v));
-    //All cotangents sum 1.0 for those triangles
-    ASSERT_EQ(1.0, C1.row(f).sum());
+       //All cotangents sum 1.0 for those triangles
+       ASSERT_EQ(1.0, C1.row(f).sum());
+#else
+      //Soft assert if we have not edge_lenght_squared
+      for(int v = 0;v<3;v++)
+        if (C1(f,v) > 0.1)
+            ASSERT_NEAR(0.5, C1(f,v), epsilon);
+        else
+            ASSERT_NEAR(0.0, C1(f,v), epsilon);
+       //All cotangents sum 1.0 for those triangles
+       ASSERT_NEAR(1.0, C1.row(f).sum(), epsilon);
+#endif
   }
 
   //Check the regular tetrahedron
@@ -58,14 +70,27 @@ TEST(cotmatrix_entries, simple)
   //All angles still measure 45 or 90 degrees
   //Their (half)cotangent must value 0.5 or 0.0
   for(int f = 0;f<C1.rows();f++)
-  {
-    for(int v = 0;v<3;v++)
+  {    
+#ifdef IGL_EDGE_LENGTHS_SQUARED_H
+      //Hard assert if we have edge_lenght_squared
+      for(int v = 0;v<3;v++)
         if (C1(f,v) > 0.1)
-           ASSERT_EQ(0.5, C1(f,v));
+            ASSERT_EQ(0.5, C1(f,v));
         else
            ASSERT_EQ(0.0, C1(f,v));
-    //All cotangents sum 1.0 for those triangles
-    ASSERT_EQ(1.0, C1.row(f).sum());
+       //All cotangents sum 1.0 for those triangles
+       ASSERT_EQ(1.0, C1.row(f).sum());
+#else
+      //Soft assert if we have not edge_lenght_squared
+      for(int v = 0;v<3;v++)
+        if (C1(f,v) > 0.1)
+            ASSERT_NEAR(0.5, C1(f,v), epsilon);
+        else
+            ASSERT_NEAR(0.0, C1(f,v), epsilon);
+       //All cotangents sum 1.0 for those triangles
+       ASSERT_NEAR(1.0, C1.row(f).sum(), epsilon);
+#endif
+
   }
 
   //Check the huge regular tetrahedron
@@ -92,7 +117,7 @@ TEST(cotmatrix_entries, simple)
         if (C1(f,v) > 0.1)
            ASSERT_NEAR(0.5, C1(f,v), epsilon);
         else
-           ASSERT_EQ(0.0, C1(f,v));
+           ASSERT_NEAR(0.0, C1(f,v), epsilon);
     //All cotangents sum 1.0 for those triangles
     ASSERT_NEAR(1.0, C1.row(f).sum(), epsilon);
   }

--- a/include/igl/cotmatrix_entries.cpp
+++ b/include/igl/cotmatrix_entries.cpp
@@ -1,0 +1,111 @@
+#include <test_common.h>
+#include <igl/cotmatrix_entries.h>
+
+TEST(cotmatrix_entries, simple)
+{
+  //The allowed error for this test
+  const double epsilon = 1e-15;
+
+  Eigen::MatrixXd V;
+  Eigen::MatrixXi F;
+  //This is a cube of dimensions 1.0x1.0x1.0
+  test_common::load_mesh("cube.obj", V, F);
+
+  //Prepare another mesh with triangles along side diagonals of the cube
+  //These triangles are form a regular tetrahedron of side sqrt(2)
+  Eigen::MatrixXi F_tet(4,3);
+  F_tet << 4,6,1,
+            6,4,3,
+            4,1,3,
+            1,6,3;
+
+  //1. Check cotmatrix_entries
+
+  Eigen::MatrixXd C1;
+  igl::cotmatrix_entries(V,F,C1);
+  ASSERT_EQ(F.rows(), C1.rows());
+  ASSERT_EQ(3, C1.cols());
+  //All angles in unit cube measure 45 or 90 degrees
+  //Their (half)cotangent must value 0.5 or 0.0
+  for(int f = 0;f<C1.rows();f++)
+  {
+    for(int v = 0;v<3;v++)
+        if (C1(f,v) > 0.1)
+           ASSERT_EQ(0.5, C1(f,v));
+        else
+           ASSERT_EQ(0.0, C1(f,v));
+    //All cotangents sum 1.0 for those triangles
+    ASSERT_EQ(1.0, C1.row(f).sum());
+  }
+
+  //Check the regular tetrahedron
+  Eigen::MatrixXd C2;
+  igl::cotmatrix_entries(V,F_tet,C2);
+  ASSERT_EQ(F_tet.rows(), C2.rows());
+  ASSERT_EQ(3, C2.cols());
+  for(int f = 0;f<C2.rows();f++)
+  {
+    //Their (half)cotangent must value 0.5 / tan(M_PI / 3.0)
+    for(int v = 0;v<3;v++)
+       ASSERT_NEAR(0.5 / tan(M_PI / 3.0), C2(f,v), epsilon);
+  }
+
+  //Scale the cube to have huge sides
+  Eigen::MatrixXd V_huge = V * 1.0e8;
+  igl::cotmatrix_entries(V_huge,F,C1);
+  ASSERT_EQ(F.rows(), C1.rows());
+  ASSERT_EQ(3, C1.cols());
+  //All angles still measure 45 or 90 degrees
+  //Their (half)cotangent must value 0.5 or 0.0
+  for(int f = 0;f<C1.rows();f++)
+  {
+    for(int v = 0;v<3;v++)
+        if (C1(f,v) > 0.1)
+           ASSERT_EQ(0.5, C1(f,v));
+        else
+           ASSERT_EQ(0.0, C1(f,v));
+    //All cotangents sum 1.0 for those triangles
+    ASSERT_EQ(1.0, C1.row(f).sum());
+  }
+
+  //Check the huge regular tetrahedron
+  igl::cotmatrix_entries(V_huge,F_tet,C2);
+  ASSERT_EQ(F_tet.rows(), C2.rows());
+  ASSERT_EQ(3, C2.cols());
+  for(int f = 0;f<C2.rows();f++)
+  {
+    //Their (half)cotangent must value 0.5 / tan(M_PI / 3.0)
+    for(int v = 0;v<3;v++)
+       ASSERT_NEAR(0.5 / tan(M_PI / 3.0), C2(f,v), epsilon);
+  }
+
+  //Scale the cube to have tiny sides
+  Eigen::MatrixXd V_tiny = V * 1.0e-8;
+  igl::cotmatrix_entries(V_tiny,F,C1);
+  ASSERT_EQ(F.rows(), C1.rows());
+  ASSERT_EQ(3, C1.cols());
+  //All angles still measure 45 or 90 degrees
+  //Their (half)cotangent must value 0.5 or 0.0
+  for(int f = 0;f<C1.rows();f++)
+  {
+    for(int v = 0;v<3;v++)
+        if (C1(f,v) > 0.1)
+           ASSERT_NEAR(0.5, C1(f,v), epsilon);
+        else
+           ASSERT_EQ(0.0, C1(f,v));
+    //All cotangents sum 1.0 for those triangles
+    ASSERT_NEAR(1.0, C1.row(f).sum(), epsilon);
+  }
+
+  //Check the tiny regular tetrahedron
+  igl::cotmatrix_entries(V_tiny,F_tet,C2);
+  ASSERT_EQ(F_tet.rows(), C2.rows());
+  ASSERT_EQ(3, C2.cols());
+  for(int f = 0;f<C2.rows();f++)
+  {
+    //Their (half)cotangent must value 0.5 / tan(M_PI / 3.0)
+    for(int v = 0;v<3;v++)
+       ASSERT_NEAR(0.5 / tan(M_PI / 3.0), C2(f,v), epsilon);
+  }
+
+}//TEST(cotmatrix_entries, simple)

--- a/include/igl/edge_lengths.cpp
+++ b/include/igl/edge_lengths.cpp
@@ -1,0 +1,186 @@
+#include <test_common.h>
+#include <igl/edge_lengths.h>
+#include <iostream>
+
+TEST(edge_lengths, simple)
+{
+    //The allowed error for this test
+    const double epsilon = 1e-15;
+
+  Eigen::MatrixXd V;
+  Eigen::MatrixXi F;
+  //This is a cube of dimensions 1.0x1.0x1.0
+  test_common::load_mesh("cube.obj", V, F);
+
+  //Create scaled versions of the cube
+  double scale = 1.0;
+  double huge_scale = 1.0e8;
+  double tiny_scale = 1.0e-8;
+  Eigen::MatrixXd V_huge = V * huge_scale;
+  Eigen::MatrixXd V_tiny = V * tiny_scale;
+
+  //Prepare another mesh with triangles along side diagonals of the cube
+  //These triangles are form a regular tetrahedron of side sqrt(2)
+  Eigen::MatrixXi F_tet(4,3);
+  F_tet << 4,6,1,
+            6,4,3,
+            4,1,3,
+            1,6,3;
+
+
+#ifdef IGL_EDGE_LENGTHS_SQUARED_H
+
+  //1. Check edge_lengths_squared function
+  double side_sq = 1.0; //squared lenght of a side
+  double diag_sq = 2.0; //squared lenght of a diagonal
+  Eigen::MatrixXd L_sq;
+  igl::edge_lengths_squared(V,F,L_sq);
+  ASSERT_EQ(F.rows(), L_sq.rows());
+  ASSERT_EQ(3, L_sq.cols());
+  //All edges in unit cube measure 1.0 or sqrt(2) in diagonals
+  for(int f = 0;f<L_sq.rows();f++)
+  {
+    //All edge_lengths_squared must be exactly "side_sq" or "diag_sq"
+    for(int e = 0;e<3;e++)
+        if (L_sq(f,e) > 1.1)
+           ASSERT_EQ(diag_sq, L_sq(f,e));
+        else
+           ASSERT_EQ(side_sq, L_sq(f,e));
+    //All sides sum exactly side_sq + side_sq + diag_sq
+    ASSERT_EQ(L_sq.row(f).sum(), side_sq + side_sq + diag_sq);
+  }
+
+  //Check the regular tetrahedron
+  igl::edge_lengths_squared(V,F_tet,L_sq);
+  ASSERT_EQ(F_tet.rows(), L_sq.rows());
+  ASSERT_EQ(3, L_sq.cols());
+  //All edges measure sqrt(2)
+  for(int f = 0;f<L_sq.rows();f++)
+  {
+      //All edge_lengths_squared must be exactly "diag_sq"
+    for(int e = 0;e<3;e++)
+       ASSERT_EQ(2.0, L_sq(f,e));
+  }
+
+
+  //Scale the cube to have huge sides
+  side_sq = huge_scale * huge_scale;  //squared lenght of a side
+  diag_sq = 2.0 * side_sq;  //squared lenght of a diagonal
+  igl::edge_lengths_squared(V_huge,F,L_sq);
+  ASSERT_EQ(F.rows(), L_sq.rows());
+  ASSERT_EQ(3, L_sq.cols());
+  for(int f = 0;f<L_sq.rows();f++)
+  {
+    //All edge_lengths_squared must be exactly side_sq or diag_sq
+    for(int e = 0;e<3;e++)
+        if (L_sq(f,e) > 1.1*side_sq)
+           ASSERT_EQ(diag_sq, L_sq(f,e));
+        else
+           ASSERT_EQ(side_sq, L_sq(f,e));
+    //All sides sum exactly side_sq + side_sq + diag_sq
+    ASSERT_EQ(L_sq.row(f).sum(), side_sq + side_sq + diag_sq);
+  }
+ 
+  //Check the equilateral triangles
+  igl::edge_lengths_squared(V_huge,F_tet,L_sq);
+  ASSERT_EQ(F_tet.rows(), L_sq.rows());
+  ASSERT_EQ(3, L_sq.cols());
+  //All edges measure sqrt(2)
+  for(int f = 0;f<L_sq.rows();f++)
+  {
+    //All edge_lengths_squared must be exactly "diag_sq"
+    for(int e = 0;e<3;e++)
+       ASSERT_EQ(diag_sq, L_sq(f,e));
+  }
+
+  //Scale the cube to have tiny sides
+  side_sq = tiny_scale * tiny_scale;  //squared lenght of a side
+  diag_sq = 2.0 * side_sq;  //squared lenght of a diagonal
+  igl::edge_lengths_squared(V_tiny,F,L_sq);
+  ASSERT_EQ(F.rows(), L_sq.rows());
+  ASSERT_EQ(3, L_sq.cols());
+  for(int f = 0;f<L_sq.rows();f++)
+  {
+    //All edge_lengths_squared must be exactly side_sq or diag_sq
+    for(int e = 0;e<3;e++)
+        if (L_sq(f,e) > 1.1*side_sq)
+           ASSERT_EQ(diag_sq, L_sq(f,e));
+        else
+           ASSERT_EQ(side_sq, L_sq(f,e));
+    //All sides sum exactly side_sq + side_sq + diag_sq
+    ASSERT_EQ(L_sq.row(f).sum(), side_sq + side_sq + diag_sq);
+  }
+
+  //Check the regular tetrahedron
+  igl::edge_lengths_squared(V_tiny,F_tet,L_sq);
+  ASSERT_EQ(F_tet.rows(), L_sq.rows());
+  ASSERT_EQ(3, L_sq.cols());
+  //All edges measure sqrt(2)
+  for(int f = 0;f<L_sq.rows();f++)
+  {
+    //All edge_lengths_squared must be exactly "diag_sq"
+    for(int e = 0;e<3;e++)
+       ASSERT_EQ(diag_sq, L_sq(f,e));
+  }
+
+#endif
+
+  //2. Check edge_lengths
+  double side = 1.0;       //lenght of a side
+  double diag = sqrt(2.0); //lenght of a diagonal
+  Eigen::MatrixXd L;
+  igl::edge_lengths(V,F,L);
+  ASSERT_EQ(F.rows(), L.rows());
+  ASSERT_EQ(3, L.cols());
+  //All edges in unit cube measure 1.0 or sqrt(2) in diagonals
+  for(int f = 0;f<L.rows();f++)
+  {
+    //All edge_lengths_squared must be exactly "side" or "diag"
+    for(int e = 0;e<3;e++)
+        if (L(f,e) > 1.1*side)
+           ASSERT_EQ(diag, L(f,e));
+        else
+           ASSERT_EQ(side, L(f,e));
+    //All sides sum exactly side + side + diag
+    ASSERT_EQ(L.row(f).sum(), side + side + diag);
+  }
+
+  //Check the cube of huge sides
+  scale = 1.0e8;
+  side = scale;       //lenght of a side
+  diag = scale*sqrt(2.0); //lenght of a diagonal
+  igl::edge_lengths(V_huge,F,L);
+  ASSERT_EQ(F.rows(), L.rows());
+  ASSERT_EQ(3, L.cols());
+  for(int f = 0;f<L.rows();f++)
+  {
+    //All edge_lengths_squared must be exactly "side" or "diag"
+    for(int e = 0;e<3;e++)
+        if (L(f,e) > 1.1*side)
+           ASSERT_EQ(diag, L(f,e));
+        else
+           ASSERT_EQ(side, L(f,e));
+    //All sides sum exactly side + side + diag
+    ASSERT_NEAR(L.row(f).sum(), side + side + diag, epsilon);
+  }
+
+  //Check the cube of tiny sides
+  scale = 1.0e-8;
+  side = scale;       //lenght of a side
+  diag = scale*sqrt(2.0); //lenght of a diagonal
+  igl::edge_lengths(V_tiny,F,L);
+  ASSERT_EQ(F.rows(), L.rows());
+  ASSERT_EQ(3, L.cols());
+  for(int f = 0;f<L.rows();f++)
+  {
+    //All edge_lengths_squared must be exactly "side" or "diag"
+    for(int e = 0;e<3;e++)
+        if (L(f,e) > 1.1*side)
+           ASSERT_EQ(diag, L(f,e));
+        else
+           ASSERT_EQ(side, L(f,e));
+    //All sides sum exactly side + side + diag
+    ASSERT_EQ(L.row(f).sum(), side + side + diag);
+  }
+
+}


### PR DESCRIPTION
Hi,

Here are some test for robustness on edge_lengths, cotmatrix_entries and cotmatrix. Also check if edge_lengths_squared is present and test only if exist.

The tests loads the unit cube (cube.obj) and create a huge and tiny scaled versions of the mesh and check know values for edges and cotangents.
Also generate a regular tetrahedron in unit, huge and tiny sizes (reusing 4 coordinates of the cube), and check values for edges and cotangents.
